### PR TITLE
Many improvements to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,49 @@
-credits for the original script go to https://github.com/rinongal/textual_inversion, my repo is another implementation
+# Stable Textual Inversion_win
 
-please read this tutorial to gain some knowledge on how it works https://www.reddit.com/r/StableDiffusion/comments/wvzr7s/tutorial_fine_tuning_stable_diffusion_using_only/
+Credits for the original script go to https://github.com/rinongal/textual_inversion, my repo is another implementation.
 
-## changelog:
-- [x] added support for windows
-- [x] added support for img2img + textual inversion
-- [x] added colab notebook that works on free colab for training textual inversion 
-- [x] made fork stable-diffusion-dream repo to support textual inversion etc.
-- [X] fixed saving last.ckpt and embeddings.pt every 500 steps
-- [X] fixed merge_embeddings.pt
-- [X] fixed resuming training
-- [X] added squarize outpainting images
+Please read this tutorial to gain some knowledge on how it works https://www.reddit.com/r/StableDiffusion/comments/wvzr7s/tutorial_fine_tuning_stable_diffusion_using_only/
 
-start with installing stable diffusion dependencies
+# Changelog
 
-```
+- [x] Added support for windows
+- [x] Added support for img2img + textual inversion
+- [x] Added colab notebook that works on free colab for training textual inversion 
+- [x] Made fork stable-diffusion-dream repo to support textual inversion etc.
+- [X] Fixed saving last.ckpt and embeddings.pt every 500 steps
+- [X] Fixed merge_embeddings.pt
+- [X] Fixed resuming training
+- [X] Added squarize outpainting images
+
+# Setup
+
+Start with installing stable diffusion dependencies
+
+```py
 conda env create -f environment.yaml
 conda activate ldm
 ```
 
-**you need to install a couple extra things on top of the ldm env for this to work**
-```
+**You need to install a couple extra packages on top of the ldm env for this to work**
+
+```py
 pip install setuptools==59.5.0
 pip install pillow==9.0.1
 pip install torchmetrics==0.6.0
 pip install -e .
 ```
 
+# Important info
 
-# training 
-**under 11/12gb vram gpu's training will not work *(for now atleast)* but you can use the colab notebook (you'll see it when u scroll down)**
+- **Out of memory error:** Try adding ```--base configs/stable-diffusion/v1-finetune_lowmemory.yaml```
+- You can follow the progress of your training by looking at the images in this folder `logs/datasetname` model time `projectname/images`.
+- It trains forever until you stop it, so just stop the training whenever you're happy with the result images in `logs/randomname/images`. You can resume training later.
 
-**to pause training you can double click inside your command prompt**
-```
+# Training
+
+**WARNING: Under 11/12gb vram gpu's training will not work *(for now atleast)*, but you can use the colab notebook (you'll see it when u scroll down).**
+
+```py
 python main.py \
  --base configs/stable-diffusion/v1-finetune.yaml \
  -t --no-test \
@@ -42,69 +53,100 @@ python main.py \
  --init_word "keyword" \
  -n "projectname" \
 ```
-#
-- if u get a out of memory error try ```--base configs/stable-diffusion/v1-finetune_lowmemory.yaml```
-- you can follow the progress of your training by looking at the images in this folder logs/datasetname model time projectname/images.
-- it trains forever until u stop it so just stop the training whenever ur happy with the result images in logs/randomname/images
-- for small datasets 3000-7000 steps are enough, all of this depends depends on the size of the dataset though. (check in the images folder to see if it's good)
-- u can stop the training by doing Ctrl+C and it will create a checkpoint.
-- you can resume training from that checkpoint (look under this)
-- results of the resumed checkpoint will be saved in the original checkpoint path but will not export the test images due to there already being test images in there, if you want test images specify a new path with -p logs/newpath
-#
-#
-**resuming** (make sure your path is specified like this ```path/path/path``` and not like this ```path\path\path``` when resuming)
+
+To ask for a init word and project name when running the command, you can create a `.bat` file like this example:
+
+```py
+@echo  off
+call %UserProfile%\miniconda3\Scripts\activate.bat ldm
+set /p "init=Enter init word: "
+set /p "projectname=Enter name of object/style: "
+
+python main.py --base configs/stable-diffusion/v1-finetune.yaml -t --no-test --actual_resume "SD/checkpoint/sd-v1-4.ckpt" --gpus 0, --data_root "PATHTOTRAINIMGIMAGES/imgs" --init_word "%init%" -n "%projectname%"
 ```
-!python "main.py" \
+
+**NOTE:** PowerShell, or some terminals may prefer `/` instead of `\` in file paths.
+
+# Stopping / Pausing
+**To stop training** use `Ctrl+C`. It will create a checkpoint, and exit.
+
+**To pause training you can double click inside your command prompt (usually):** Selecting text usually pauses command prompt windows, but may not work in some terminals, like VSCode.
+
+- For small datasets 3000-7000 steps are enough. All of this depends depends on the size of the dataset. Check in the images folder to see if you're getting a good result.
+- Results of the resumed checkpoint will be saved in the original checkpoint path.
+- You can later resume training from a checkpoint...
+
+# Resuming
+
+Make sure your path is specified with forward slashes `/`, instead of back slashes `\`. For example: ```path\path\path``` becomes ```path/path/path``` when resuming.
+
+Check your `./logs` folder to see the last training sessions folder. It is in the format `imgs<DateTime>_<ProjectName>`. Replace `FOLDERNAME` with your folder's name.
+
+```py
+python "main.py" \
  --base "configs/stable-diffusion/v1-finetune.yaml" \
  -t --no-test \
  --actual_resume " models/ldm/stable-diffusion-v1/model.ckpt" \
  --gpus 0 \
  --data_root "C:/path/to/training/images" \
- --init_word "keyword u used when training" \
- --project "logs/training images2022-08-28T07-55-48_myProjectName" \
- --embedding_manager_ckpt ""logs/datasetname model time projectname/checkpoints/embeddings.pt" \
- --resume_from_checkpoint "logs/datasetname model time projectname/checkpoints/last.ckpt" \
- -n "myProjectName2"
+ --resume "logs/FOLDERNAME" \
+ -l logs \
+ --embedding_manager_ckpt "logs/FOLDERNAME/checkpoints/embeddings.pt" \
+ --resume_from_checkpoint "logs/FOLDERNAME/checkpoints/last.ckpt"
 ```
-#
-#
-**merge trained models together**
 
-(make sure you use different symbols in placeholder_strings: ["*"] (in the .yaml file while trainig) if u want to use this)
+You can use replace `FOLDERNAME` with `%text%`, a variable, and add a prompt when launching. You can type in text when you run the script, instead of needing to modify it. Simply use a `.bat` file, like the example below.
 
-```
-python merge_embeddings.py --manager_ckpts /path/to/first/embedding.pt /path/to/second/embedding.pt [...] --output_path /path/to/output/embedding.pt
-```
-#
-#
-**colab notebook for training if your gpu is not good enough to train. (free colab version works)**
-https://colab.research.google.com/drive/1MggyUS5BWyNdoXpzGkroKgVoKlqJm7vI?usp=sharing
-#
-#
-**use this repo for runpod**
-https://github.com/GamerUntouch/textual_inversion
+```py
+@echo  off
+call %UserProfile%\miniconda3\Scripts\activate.bat ldm
+set /p "text=Enter last (/logs) folder name: "
 
-# 
-#
-# generating
-**for image easy image generation use this repo (text weights + txt2img + img2img + Textual Inversion all supported at once)**
-https://github.com/lstein/stable-diffusion
-windows
+python main.py --base configs/stable-diffusion/v1-finetune.yaml -t --actual_resume "SD/checkpoint/sd-v1-4.ckpt" --gpus 0, --data_root "PATHTOTRAINIMGIMAGES/imgs" --resume "logs/%text%" -l logs --embedding_manager_ckpt "logs/%text%/checkpoints/embeddings.pt" --resume_from_checkpoint "logs/%text%/checkpoints/last.ckpt"
 ```
-python ./scripts/dream.py --embedding_path /path/to/embedding.pt --full_precision
-```
-linux
-```
-python3 ./scripts/dream.py --embedding_path /path/to/embedding.pt --full_precision
-```
-#
-#
 
-# An Image is Worth One Word: Personalizing Text-to-Image Generation using Textual Inversion
+# Merge trained models together
+
+Make sure you use different symbols in placeholder_strings: ["*"] (in the .yaml file while training) if u want to use this.
+
+```py
+python merge_embeddings.py --manager_ckpts "/path/to/first/embedding.pt" "/path/to/second/embedding.pt" [...] --output_path "/path/to/output/embedding.pt"
+```
+
+# Running this script elsewhere
+
+## Google Colab
+ 
+ You can use a Google Colab notebook for training if your GPU is not good enough to run this program. The free version of Google Colab is a good place to start. A note on Google Colab is that there are now limits, implemented in a recent update.
+
+Textual inversion/finetuning script: https://colab.research.google.com/drive/1MggyUS5BWyNdoXpzGkroKgVoKlqJm7vI?usp=sharing
+
+## Runpod
+You can run this repo on Runpod. See "Running Textual Inversion on RunPod using JuptyrLab": https://github.com/GamerUntouch/textual_inversion
+
+# Generating images
+**For easy image generation: Try [lstein/Stable Diffusion](https://github.com/lstein/stable-diffusion).**
+
+Text weights, txt2img, img2img, and Textual Inversion are all supported.
+
+Windows
+```py
+python ./scripts/dream.py --embedding_path "/path/to/embedding.pt" --full_precision
+```
+Linux
+```py
+python3 ./scripts/dream.py --embedding_path "/path/to/embedding.pt" --full_precision
+```
+
+---
+
+# Read more about Textual Inversion
+
+To learn more about textual inversion, see the [Official Github.io page](https://textual-inversion.github.io/).
+
+The official repo contains the official code, data and sample inversions for the Textual Inversion paper. Find the [Official GitHub repo](https://github.com/rinongal/textual_inversion).
 
 [![arXiv](https://img.shields.io/badge/arXiv-2208.01618-b31b1b.svg)](https://arxiv.org/abs/2208.01618)
-
-[[Project Website](https://textual-inversion.github.io/)]
 
 > **An Image is Worth One Word: Personalizing Text-to-Image Generation using Textual Inversion**<br>
 > Rinon Gal<sup>1,2</sup>, Yuval Alaluf<sup>1</sup>, Yuval Atzmon<sup>2</sup>, Or Patashnik<sup>1</sup>, Amit H. Bermano<sup>1</sup>, Gal Chechik<sup>2</sup>, Daniel Cohen-Or<sup>1</sup> <br>
@@ -120,108 +162,9 @@ python3 ./scripts/dream.py --embedding_path /path/to/embedding.pt --full_precisi
   Notably, we find evidence that a <i>single</i> word embedding is sufficient for capturing unique and varied concepts.
   We compare our approach to a wide range of baselines, and demonstrate that it can more faithfully portray the concepts across a range of applications and tasks.
 
-## Description
-This repo contains the official code, data and sample inversions for our Textual Inversion paper. 
+## Citation for Textual Inversion
 
-## Updates
-**21/08/2022 (C)** Code released!
-
-## TODO:
-- [x] Release code!
-- [x] Optimize gradient storing / checkpointing. Memory requirements, training times reduced by ~55%
-- [ ] Release data sets
-- [ ] Release pre-trained embeddings
-- [ ] Add Stable Diffusion support
-
-## Setup
-
-Our code builds on, and shares requirements with [Latent Diffusion Models (LDM)](https://github.com/CompVis/latent-diffusion). To set up their environment, please run:
-
-```
-conda env create -f environment.yaml
-conda activate ldm
-```
-
-You will also need the official LDM text-to-image checkpoint, available through the [LDM project page](https://github.com/CompVis/latent-diffusion). 
-
-Currently, the model can be downloaded by running:
-
-```
-mkdir -p models/ldm/text2img-large/
-wget -O models/ldm/text2img-large/model.ckpt https://ommer-lab.com/files/latent-diffusion/nitro/txt2img-f8-large/model.ckpt
-```
-
-## Usage
-
-### Inversion
-
-To invert an image set, run:
-
-```
-python main.py --base configs/latent-diffusion/txt2img-1p4B-finetune.yaml 
-               -t 
-               --actual_resume /path/to/pretrained/model.ckpt 
-               -n <run_name> 
-               --gpus 0, 
-               --data_root /path/to/directory/with/images
-               --init_word <initialization_word>
-```
-
-where the initialization word should be a single-token rough description of the object (e.g., 'toy', 'painting', 'sculpture'). If the input is comprised of more than a single token, you will be prompted to replace it.
-
-In the paper, we use 5k training iterations. However, some concepts (particularly styles) can converge much faster.
-
-To run on multiple GPUs, provide a comma-delimited list of GPU indices to the --gpus argument (e.g., ``--gpus 0,3,7,8``)
-
-Embeddings and output images will be saved in the log directory.
-
-See `configs/latent-diffusion/txt2img-1p4B-finetune.yaml` for more options, such as changing the placeholder string which denotes the concept (defaults to "*")
-
-**Important** All training set images should be upright. If you are using phone captured images, check the inputs_gs*.jpg files in the output image directory and make sure they are oriented correctly. Many phones capture images with a 90 degree rotation and denote this in the image metadata. Windows parses these correctly, but PIL does not. Hence you will need to correct them manually (e.g. by pasting them into paint and re-saving) or wait until we add metadata parsing.
-
-### Generation
-
-To generate new images of the learned concept, run:
-```
-python scripts/txt2img.py --ddim_eta 0.0 
-                          --n_samples 8 
-                          --n_iter 2 
-                          --scale 10.0 
-                          --ddim_steps 50 
-                          --embedding_path /path/to/logs/trained_model/checkpoints/embeddings_gs-5049.pt 
-                          --ckpt_path /path/to/pretrained/model.ckpt 
-                          --prompt "a photo of *"
-```
-
-where * is the placeholder string used during inversion.
-
-### Merging Checkpoints
-
-LDM embedding checkpoints can be merged into a single file by running:
-
-```
-python merge_embeddings.py 
---manager_ckpts /path/to/first/embedding.pt /path/to/second/embedding.pt [...]
---output_path /path/to/output/embedding.pt
-```
-
-If the checkpoints contain conflicting placeholder strings, you will be prompted to select new placeholders. The merged checkpoint can later be used to prompt multiple concepts at once ("A photo of * in the style of @").
-
-### Pretrained Models / Data
-Coming soon
-
-## Stable Diffusion
-
-Stable Diffusion support is a work in progress and will be completed soon™.
-
-## Tips and Tricks
-- Adding "a photo of" to the prompt usually results in better target consistency.
-- Results can be seed sensititve. If you're unsatisfied with the model, try re-inverting with a new seed (by adding `--seed <#>` to the prompt).
-
-
-## Citation
-
-If you make use of our work, please cite our paper:
+The Textual Inversion repo asks to cite the paper. Information can be seen below:
 
 ```
 @misc{gal2022textual,


### PR DESCRIPTION
- While the code blocks aren't python, it adds color making them easier to read and understand (IMO)
- The windows terminal seems to prefer `/` for filepaths. It uses `\` for escaping
- Removed info about new test images not being added to folder (new images appear for me when resuming training, I assume this was updated?) Among other changes.

Please do check to see if I've missed anything, or improperly documented things. This should be a great improvement for readability.